### PR TITLE
fix vite error, make api endpoints relative (no hardcoded url)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-  <title><%= htmlWebpackPlugin.options.title %></title>
+  <link rel="icon" href="/favicon.ico">
+  <title>Ruqqus</title>
 </head>
 <body>
   <noscript>
-    <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    <strong>We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
   </noscript>
   <div id="app"></div>
   <!-- built files will be auto injected -->

--- a/src/api/Account.js
+++ b/src/api/Account.js
@@ -4,7 +4,7 @@
 import axios from 'axios';
 
 //const url = `/account/`
-const url = `https://08816b9e-9bc2-436d-96b5-621552da59d0.mock.pstmn.io/v2/account/`
+const url = `/api/v2/account/`
 
 // Return all public info given account username (or id)
 export function getAccount(id){

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -3,7 +3,7 @@
 
 import axios from 'axios';
 
-const url = 'https://ed938631-cc32-4bb1-805e-ae9a7f5b4bca.mock.pstmn.io/v2/feed/'
+const url = '/api/v2/feed/'
 
 // Return a posts of a feed. For demonstration purposes.
 export function getFeed(type, params) {

--- a/src/api/Post.js
+++ b/src/api/Post.js
@@ -3,7 +3,7 @@
 
 import axios from 'axios';
 
-const url = 'https://e7c49a6d-8ce7-466c-992e-7cf3e6e2d110.mock.pstmn.io/v2/post/'
+const url = '/api/v2/post/'
 
 // Return post info given id
 export function getPost(id){

--- a/src/api/Site.js
+++ b/src/api/Site.js
@@ -4,7 +4,7 @@
 import axios from 'axios';
 
 //const url = `/site`
-const url = 'http://ruqqus.localhost:8000/api/v2/site';
+const url = '/api/v2/site';
 
 // Return all public site info
 export function getSite(){

--- a/src/store/modules/persist.js
+++ b/src/store/modules/persist.js
@@ -151,7 +151,7 @@ const actions = {
 
 		axios({
 			method: 'post',
-			url: 'http://ruqqus.localhost:8000/api/v2/login',
+			url: '/api/v2/login',
 			data: data,
 			headers: headers
 		})
@@ -205,36 +205,43 @@ const actions = {
 		data.append('password', form.password);
 		data.append('email', form.email)
 
-		axios({
-			method: 'post',
-			url: 'http://ruqqus.localhost:8000/api/v2/signup',
-			data: data,
-			headers: headers
-		})
-		.then(
-			function(response){
+		// Make a post request to sign up
+		// FIXME: Implement /signup/ route
+		// 		  After posting /signup/ this should redirect to the onboarding page.
 
-				if (response.status === 200) {
-					commit("SET_AUTH_USER", response.data.v);
-					commit("AUTHENTICATE", true);
-					router.push("/");
-				} else{
-						commit("SET_AUTH_USER", {});
-						commit("AUTHENTICATE", false);
-					}
-				})
-		.catch(error => {
-			commit("SET_AUTH_USER", {});
-			commit("AUTHENTICATE", false);
-			dispatch('toasts/addNotification', {
-				type: 'error',
-				header: 'Error registering',
-				message: error.response.data.error
-			},
-			{
-				root: true
-			})
-		})
+			commit("SET_AUTH_USER", data);
+			commit("AUTHENTICATE", true);
+			router.push("/");
+		// axios({
+		// 	method: 'post',
+		// 	url: '/api/v2/signup',
+		// 	data: data,
+		// 	headers: headers
+		// })
+		// .then(
+		// 	function(response){
+
+		// 		if (response.status === 200) {
+		// 			commit("SET_AUTH_USER", response.data.v);
+		// 			commit("AUTHENTICATE", true);
+		// 			router.push("/");
+		// 		} else{
+		// 				commit("SET_AUTH_USER", {});
+		// 				commit("AUTHENTICATE", false);
+		// 			}
+		// 		})
+		// .catch(error => {
+		// 	commit("SET_AUTH_USER", {});
+		// 	commit("AUTHENTICATE", false);
+		// 	dispatch('toasts/addNotification', {
+		// 		type: 'error',
+		// 		header: 'Error registering',
+		// 		message: error.response.data.error
+		// 	},
+		// 	{
+		// 		root: true
+		// 	})
+		// })
 		commit("changeLoadingState", false);
 	},
 	verify_mfa({commit, state}, form){

--- a/src/store/modules/site.js
+++ b/src/store/modules/site.js
@@ -20,7 +20,7 @@ const mutations = {
 }
 
 const actions = {
-	fetchSite({ state, commit, rootState }) {
+	fetchSite({ commit, dispatch, rootState }) {
 		getSite()
 		.then(response => {
 			let data = response.data


### PR DESCRIPTION
Before the url for some APIs was `ruqqus.localhost`, even though there's no point to it. It can just be eg. `/signup` and work with any url